### PR TITLE
Added health check and compose.yml with dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 target/
 .mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,69 @@
+volumes:
+  postgres_data:
+  redis_data:
+  rabbitmq_data:
+
+services:
+  rabbitmq:
+    image: rabbitmq:4.1-management
+    container_name: bankapp-auth-rabbitmq
+    restart: unless-stopped
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USERNAME:-admin}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:-password}
+      RABBITMQ_DEFAULT_VHOST: ${RABBITMQ_VHOST:-/}
+    ports:
+      - "5672:5672"     # AMQP port
+      - "15672:15672"   # Management UI port
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+
+  db:
+    image: postgres:15-alpine
+    container_name: bankapp-auth-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${DB_SCHEMA}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "${DB_PORT}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    container_name: bankapp-auth-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+#    command: redis-server --requirepass ${REDIS_PASSWORD}
+#    ports:
+#      - "${REDIS_PORT}:6379"
+#    volumes:
+#      - redis_data:/data
+
+#  app:
+#    build:
+#      context: .
+#      dockerfile: Dockerfile
+#    container_name: bankapp-auth-service
+#    restart: unless-stopped
+#    environment:
+#      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-prod}
+#      DB_URL: db
+#      DB_PORT: 5432
+#      DB_SCHEMA: ${DB_SCHEMA}
+#      DB_USERNAME: ${DB_USERNAME}
+#      DB_PASSWORD: ${DB_PASSWORD}
+#      REDIS_HOSTNAME: redis
+#      REDIS_PASSWORD: ${REDIS_PASSWORD}
+#      REDIS_PORT: 6379
+#      SESSION_NAMESPACE: ${SESSION_NAMESPACE}
+#    ports:
+#      - "8080:8080"
+#    depends_on:
+#      - db
+#      - redis
+#    networks:
+#      - bankapp-network

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,10 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,17 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/me.paulschwarz/spring-dotenv -->
+        <dependency>
+            <groupId>me.paulschwarz</groupId>
+            <artifactId>spring-dotenv</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-docker-compose</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=auth-service

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,61 @@
+spring:
+  application:
+    name: auth-service
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:prod}
+  datasource:
+    url: jdbc:postgresql://${DB_URL}:${DB_PORT:5432}/${DB_SCHEMA}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+    # Connection pool settings
+    hikari:
+      maximum-pool-size: 5
+      minimum-idle: 2
+      connection-timeout: 20000
+      idle-timeout: 300000
+  # JPA / Hibernate settings
+  jpa:
+    hibernate.ddl-auto: none
+    show-sql: false
+    open-in-view: false
+    properties:
+      hibernate:
+        '[show_sql]': false
+        '[format_sql]': true
+        '[globally_quoted_identifiers]': true
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USERNAME:admin}
+    password: ${RABBITMQ_PASSWORD:password}
+    virtual-host: ${RABBITMQ_VHOST:/}
+    connection-timeout: 30000
+    listener:
+      simple:
+        retry:
+          enabled: true
+          initial-interval: 1000
+          max-attempts: 3
+#  data:
+#    redis:
+#      host: ${REDIS_HOSTNAME:localhost}
+##      password: ${REDIS_PASSWORD}
+#      port: ${REDIS_PORT:6379}
+#  session:
+#    redis:
+#      flush-mode: on_save
+#      namespace: ${SESSION_NAMESPACE}
+logging:
+  level:
+    org.springframework.security: DEBUG
+    online.bankapp.authservice: TRACE
+# For Health / Actuator Data #
+management:
+  endpoint:
+    health:
+      show-details: always
+  endpoints:
+    web:
+      exposure:
+        include: '*'


### PR DESCRIPTION
health check visible at endpoint `hostname/actuator/health`
Also added compose.yml with redis/db/rabbitmq as it will be needed later on. 
compose.yml is starting with `mvn spring-boot:run` so nothing else is needed for local deployment.
its possible by because added 
```
        <dependency>
            <groupId>org.springframework.boot</groupId>
            <artifactId>spring-boot-docker-compose</artifactId>
            <scope>runtime</scope>
        </dependency>
```

part of #A-08